### PR TITLE
updates for AbstractTrees v0.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '0.7'
-          - '1.0'
           - '1.6'
           - '1'
 #          - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "LeftChildRightSiblingTrees"
 uuid = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.1.4"
+version = "0.2.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 
 [compat]
 AbstractTrees = "0.4"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,14 @@
 name = "LeftChildRightSiblingTrees"
 uuid = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.1.3"
+version = "0.1.4"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 
 [compat]
-AbstractTrees = "0.3"
-julia = "0.7, 1"
+AbstractTrees = "0.4"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/LeftChildRightSiblingTrees.jl
+++ b/src/LeftChildRightSiblingTrees.jl
@@ -1,5 +1,7 @@
 module LeftChildRightSiblingTrees
 
+using AbstractTrees
+
 # See `abstracttrees.jl` for the only dependency of this package
 
 export Node,
@@ -103,7 +105,7 @@ end
 
 Returns `true` if `node` is the root of a tree (meaning, it is its own parent).
 """
-isroot(n::Node) = n == n.parent
+AbstractTrees.isroot(n::Node) = n == n.parent
 
 """
     islastsibling(node)

--- a/src/abstracttrees.jl
+++ b/src/abstracttrees.jl
@@ -1,18 +1,17 @@
-# This file provides support for the AbstractTrees interface.
 
-using AbstractTrees
+AbstractTrees.nodetype(::Type{<:Node{T}}) where T = Node{T}
+AbstractTrees.NodeType(::Type{<:Node{T}}) where T = HasNodeType()
 
-# Traits
-Base.eltype(::Type{<:TreeIterator{Node{T}}}) where T = Node{T}
-Base.IteratorEltype(::Type{<:TreeIterator{Node{T}}}) where T = Base.HasEltype()
-Base.parent(node::Node, state::Node) = state.parent
+AbstractTrees.parent(node::Node) = node.parent ≡ node ? nothing : node.parent
 
-AbstractTrees.parentlinks(::Type{Node{T}}) where T = AbstractTrees.StoredParents()
-AbstractTrees.siblinglinks(::Type{Node{T}}) where T = AbstractTrees.StoredSiblings()
-AbstractTrees.rootstate(node::Node) = node
+AbstractTrees.ParentLinks(::Type{<:Node{T}}) where T = StoredParents()
+AbstractTrees.SiblingLinks(::Type{<:Node{T}}) where T = StoredSiblings()
+
 AbstractTrees.children(node::Node) = node
-function AbstractTrees.nextsibling(tree::Node, state::Node)
-    ns = state.sibling
-    return state === ns ? nothing : ns
+
+function AbstractTrees.nextsibling(node::Node)
+    ns = node.sibling
+    return node ≡ ns ? nothing : ns
 end
-AbstractTrees.printnode(io::IO, node::Node) = print(io, node.data)
+
+AbstractTrees.nodevalue(node::Node) = node.data


### PR DESCRIPTION
This PR contains updates for the upcoming `AbstractTrees` v0.4 (which, as of writing, is yet to be tagged).

I took the liberty of changing `isroot` to be a method of `AbstractTrees.isroot`.  I suppose technically this is breaking, but I think it's very unlikely to break any dependencies.  There's nothing preventing us from reverting this change, but it seemed silly to have two separate functions, so I changed it.

I've also removed compatibility with and CI for julia before 1.6.  Since 1.6 has been LTS for a while now, I assume this will be uncontroversial.

I will update here when AbstractTrees v0.4 is tagged.
