### PR TITLE
Fix tree-corruption bugs from confusing identity with equivalence

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LeftChildRightSiblingTrees"
 uuid = "1d6d02ad-be62-4b6b-8a6d-2f90e265016e"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/LeftChildRightSiblingTrees.jl
+++ b/src/LeftChildRightSiblingTrees.jl
@@ -12,6 +12,7 @@ export Node,
     isroot,
     isleaf,
     islastsibling,
+    isequiv,
     lastsibling,
     prunebranch!,
     copy_subtree
@@ -75,7 +76,7 @@ Append a new "youngest" sibling, storing `data` in `node`. `oldersib` must be
 the previously-youngest sibling (see [`lastsibling`](@ref)).
 """
 function addsibling(oldersib::Node{T}, data) where T
-    if oldersib.sibling != oldersib
+    if !islastsibling(oldersib)
         error("Truncation of sibling list")
     end
     youngersib = Node(data, oldersib.parent)
@@ -92,7 +93,7 @@ This adjusts all links to ensure the integrity of the tree.
 function addchild(parent::Node{T}, data) where T
     newc = Node(data, parent)
     prevc = parent.child
-    if prevc == parent
+    if prevc === parent
         parent.child = newc
     else
         prevc = lastsibling(prevc)
@@ -111,7 +112,7 @@ function addchild(parent::Node{T}, data::Node{T}) where T
         error("Child node must be a root node")
     end
     prevc = parent.child
-    if prevc == parent
+    if prevc === parent
         parent.child = data
     else
         prevc = lastsibling(prevc)
@@ -150,7 +151,7 @@ end
 
 Returns `true` if `node` is the root of a tree (meaning, it is its own parent).
 """
-AbstractTrees.isroot(n::Node) = n == n.parent
+AbstractTrees.isroot(n::Node) = n === n.parent
 
 """
     islastsibling(node)
@@ -164,7 +165,7 @@ islastsibling(n::Node) = n === n.sibling
 
 Returns `true` if `node` has no children.
 """
-isleaf(n::Node) = n == n.child
+isleaf(n::Node) = n === n.child
 
 makeleaf!(n::Node) = n.child = n
 
@@ -231,6 +232,8 @@ Move the children of `src` to become children of `dest`.
 `src` becomes a leaf node.
 """
 function graftchildren!(dest, src)
+    # With no children to move, `dest` is left untouched and `src` is already a leaf.
+    isleaf(src) && return dest
     for c in src
         c.parent = dest
     end
@@ -252,7 +255,7 @@ Eliminate `node` and all its children from the tree.
 function prunebranch!(node)
     isroot(node) && error("cannot prune the root")
     p = node.parent
-    if p.child == node
+    if p.child === node
         # `node` is the first child of p
         if islastsibling(node)
             makeleaf!(p)   # p is now a leaf
@@ -263,8 +266,8 @@ function prunebranch!(node)
         # `node` is a middle or last child of p
         child = p.child
         sib = child.sibling
-        while sib != node
-            @assert sib != child
+        while sib !== node
+            @assert sib !== child
             child = sib
             sib = child.sibling
         end
@@ -279,7 +282,17 @@ function prunebranch!(node)
     return p
 end
 
-function Base.:(==)(a::Node, b::Node)
+"""
+    isequiv(a::Node, b::Node)
+
+Return `true` if the subtrees rooted at `a` and `b` have the same shape and
+equal `data` at every corresponding node.
+
+This is a comparison by value: it can return `true` for two distinct objects.
+To test whether `a` and `b` are the same node, use `a === b`. Note that `==`
+and `isequal` on `Node`s test identity, not equivalence.
+"""
+function isequiv(a::Node, b::Node)
     a.data == b.data || return false
     reta, retb = iterate(a), iterate(b)
     while true
@@ -287,7 +300,7 @@ function Base.:(==)(a::Node, b::Node)
         ((reta === nothing) || (retb === nothing)) && return false
         childa, statea = reta
         childb, stateb = retb
-        childa == childb || return false
+        isequiv(childa, childb) || return false
         reta, retb = iterate(a, statea), iterate(b, stateb)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,10 +100,15 @@ end
 
     tree1 = mumtree()
     tree2 = mumtree()
-    @test tree1 == tree2
+    # Two trees built separately from the same recipe hold equal data in the
+    # same arrangement, so they are equivalent, but they are not the same object.
+    @test isequiv(tree1, tree2)
+    @test tree1 != tree2
+    @test tree1 == tree1
     c = collect(tree1)
     addchild(last(c), "Kid")
-    @test tree1 != tree2
+    # Growing one tree leaves the other behind, so they are no longer equivalent.
+    @test !isequiv(tree1, tree2)
 
     root = Node(1)
     otherroot = Node(2)
@@ -152,4 +157,79 @@ end
     @test map(x->x.data, @inferred(collect(PostOrderDFS(root)))) == [1,4,5,2,3,0]
     @test map(x->x.data, @inferred(collect(PreOrderDFS(root)))) == [0,1,2,4,5,3]
     @test map(x->x.data, @inferred(collect(Leaves(root)))) == [1,4,5,3]
+end
+
+@testset "node identity vs. equivalence" begin
+    # `==` on nodes reports identity: a node equals only itself.
+    a = Node(1)
+    b = Node(1)
+    @test a == a
+    @test a != b
+    @test !isequal(a, b)
+
+    # Because equality is identity, equivalent-but-distinct trees are distinct
+    # keys in a Dict or Set.
+    addchild(a, 2)
+    addchild(b, 2)
+    @test isequiv(a, b)
+    d = Dict(a => "a", b => "b")
+    @test length(d) == 2
+    @test d[a] == "a" && d[b] == "b"
+
+    # `isequiv` compares trees by shape and by the data at each node.
+    c = Node(1); addchild(c, 99)            # same shape as `a`, different leaf data
+    @test !isequiv(a, c)
+    e = Node(1); addchild(e, 2); addchild(e, 3)   # an extra child relative to `a`
+    @test !isequiv(a, e)
+    @test isequiv(a, a)
+end
+
+@testset "graftchildren! with a childless source" begin
+    # Moving the children of a leaf means moving nothing: the destination is
+    # unchanged and the source keeps its place and its parent.
+    root = Node(0)
+    keeper = addchild(root, 1)
+    branch = addchild(root, 2)
+    leafy = addchild(branch, 3)
+    graftchildren!(root, leafy)
+    @test [c.data for c in root] == [1, 2]
+    @test [c.data for c in branch] == [3]
+    @test leafy.parent === branch
+    @test isleaf(leafy)
+end
+
+@testset "prunebranch! targets the requested node" begin
+    # A sibling holding the same data must not be mistaken for the target.
+    root = Node(0)
+    firstchild = addchild(root, 7)
+    victim = addchild(root, 7)
+    addchild(root, 9)
+    prunebranch!(victim)
+    @test [c.data for c in root] == [7, 9]
+    @test collect(root)[1] === firstchild
+
+    # The target is found even when an earlier sibling carries equal data.
+    root = Node(0)
+    addchild(root, 1)
+    survivor = addchild(root, 5)
+    addchild(root, 3)
+    victim = addchild(root, 5)
+    prunebranch!(victim)
+    @test [c.data for c in root] == [1, 5, 3]
+    @test collect(root)[2] === survivor
+end
+
+@testset "operations do not assume data equals itself" begin
+    # `NaN` is not equal to itself, so tree queries and construction must rely
+    # on object identity rather than on comparing data.
+    r = Node(NaN)
+    @test isroot(r)
+    @test isleaf(r)
+    @test islastsibling(r)
+
+    child = addchild(r, 1.0)
+    @test !isleaf(r)
+    @test !isroot(child)
+    @test child.parent === r
+    @test [c.data for c in r] == [1.0]
 end


### PR DESCRIPTION
## Background

`Base.:(==)` on `Node` was overloaded to perform a deep, recursive
*structural* comparison of subtrees. Several core functions, however, used
`==`/`!=` where they needed *object identity*. That mismatch produced silent
tree corruption in cases that were rare enough to go unnoticed.

## Bugs fixed

**`prunebranch!` could remove the wrong branch.** It located the target node
with `==`, so a sibling holding equal data (and an equal subtree) was
mistaken for the node to prune.

```julia
root = Node(0)
addchild(root, 7); s2 = addchild(root, 7); addchild(root, 9)
prunebranch!(s2)   # before: [9]   — both 7s gone;   after: [7, 9]
```

**`addchild`/`isroot`/`isleaf` broke on data where `x == x` is false.** For
`NaN`-like data, a genuine root/leaf misreported and `addchild` attached the
node as a *sibling* instead of a child, silently dropping it from the
children list.

**`graftchildren!` corrupted the tree when `src` was a leaf.** With no
children to move it spliced `src` itself into `dest`'s child list and left
`src.parent` stale, instead of being a no-op. This is the path FlameGraphs
reaches via `prunerepl!` when a backtrace bottoms out at `eval_user_input` —
the suspected cause of occasional nonsensical profiles.

**`Node` defined `==` without a matching `hash`**, violating the
`isequal`/`hash` contract and making `Dict`/`Set` keys unreliable.

## Change

Equality on `Node` is now identity-based, matching expectations for a node
type and restoring a consistent default `hash`. The structural comparison is
preserved as the new exported function `isequiv`. Internal link checks use
`===`.

Because the meaning of `==` on `Node` changes, this is **breaking**: version
bumped to 0.3.0.

Regression tests cover each flavor: identity vs. equivalence, `graftchildren!`
with a childless source, `prunebranch!` with equal-valued siblings, and
operations on data that is not equal to itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)