### PR TITLE
`AbstractTrees.children` returns iterator type

### DIFF
--- a/src/LeftChildRightSiblingTrees.jl
+++ b/src/LeftChildRightSiblingTrees.jl
@@ -185,18 +185,6 @@ function Base.iterate(n::Node, state::Node = n.child)
     return state, islastsibling(state) ? n : state.sibling
 end
 
-# To support Base.pairs
-struct PairIterator{T}
-    parent::Node{T}
-end
-Base.pairs(node::Node) = PairIterator(node)
-Base.IteratorSize(::Type{<:PairIterator}) = Base.SizeUnknown()
-
-function Base.iterate(iter::PairIterator, state::Node=iter.parent.child)
-    iter.parent === state && return nothing
-    return state=>state, islastsibling(state) ? iter.parent : state.sibling
-end
-
 function showedges(io::IO, parent::Node, printfunc = identity)
     str = printfunc(parent.data)
     if str != nothing

--- a/src/abstracttrees.jl
+++ b/src/abstracttrees.jl
@@ -1,4 +1,20 @@
 
+"""
+    ChildIterator(node)
+
+A lightweight iterator over the direct children of `node`. This is the value
+returned by `AbstractTrees.children`; iterating it yields each child `Node`.
+"""
+struct ChildIterator{T}
+    parent::Node{T}
+end
+
+Base.IteratorSize(::Type{<:ChildIterator}) = Base.SizeUnknown()
+Base.eltype(::Type{ChildIterator{T}}) where T = Node{T}
+
+Base.iterate(iter::ChildIterator) = iterate(iter.parent)
+Base.iterate(iter::ChildIterator, state::Node) = iterate(iter.parent, state)
+
 AbstractTrees.nodetype(::Type{<:Node{T}}) where T = Node{T}
 AbstractTrees.NodeType(::Type{<:Node{T}}) where T = HasNodeType()
 
@@ -7,7 +23,7 @@ AbstractTrees.parent(node::Node) = node.parent ≡ node ? nothing : node.parent
 AbstractTrees.ParentLinks(::Type{<:Node{T}}) where T = StoredParents()
 AbstractTrees.SiblingLinks(::Type{<:Node{T}}) where T = StoredSiblings()
 
-AbstractTrees.children(node::Node) = node
+AbstractTrees.children(node::Node) = ChildIterator(node)
 
 function AbstractTrees.nextsibling(node::Node)
     ns = node.sibling

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -157,6 +157,13 @@ end
     @test map(x->x.data, @inferred(collect(PostOrderDFS(root)))) == [1,4,5,2,3,0]
     @test map(x->x.data, @inferred(collect(PreOrderDFS(root)))) == [0,1,2,4,5,3]
     @test map(x->x.data, @inferred(collect(Leaves(root)))) == [1,4,5,3]
+
+    # `children` returns a distinct iterator type rather than the node itself (issue #6)
+    ch = AbstractTrees.children(root)
+    @test ch isa LeftChildRightSiblingTrees.ChildIterator
+    @test eltype(ch) === Node{Int}
+    @test map(x->x.data, collect(ch)) == [1,2,3]
+    @test isempty(collect(AbstractTrees.children(c1)))
 end
 
 @testset "node identity vs. equivalence" begin


### PR DESCRIPTION
`children(node)` previously returned the node itself, so `children(node) === node`. Return a lightweight `ChildIterator` wrapper instead: it is self-describing, iterates the direct children with no allocation, and no longer invites confusion about a node being its own child collection.

Also remove the now-unreachable `PairIterator`/`Base.pairs(::Node)`. These existed only to satisfy AbstractTrees 0.3's `print_tree`, which called `pairs` on the children unconditionally; AbstractTrees 0.4 guards that path with `applicable(keys, children)`, and no `keys(::Node)` method exists.

Fixes #6